### PR TITLE
Provide access to path in validation

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,6 +9,7 @@
     "provides": {
         "JsonHound::Violation": "lib/JsonHound/Violation.pm6",
         "JsonHound::RuleSet": "lib/JsonHound/RuleSet.pm6",
+        "JsonHound::PathMixin": "lib/JsonHound/PathMixin.pm6",
         "JsonHound": "lib/JsonHound.pm6"
     },
     "name": "JSONHound",

--- a/bin/jsonhound
+++ b/bin/jsonhound
@@ -49,7 +49,8 @@ sub MAIN(
             $message ~= "  " ~ colored("$v.name()", "underline") ~
                     " $v.file.IO.basename():$v.line()\n";
             for $v.arguments.sort(*.key).map(|*.kv) -> $name, $json {
-                $message ~= colored("    $name:\n", "bold");
+                $message ~= colored("    $name: ", "bold");
+                $message ~= colored("$json.path()\n", "blue");
                 $message ~= to-json($json).indent(6) ~ "\n";
             }
         }

--- a/lib/JsonHound/PathMixin.pm6
+++ b/lib/JsonHound/PathMixin.pm6
@@ -1,0 +1,5 @@
+#| Mixed in to found pieces of the document, carrying the path that they are
+#| located at.
+role JsonHound::PathMixin {
+    has Str $.path is required;
+}

--- a/lib/JsonHound/RuleSet.pm6
+++ b/lib/JsonHound/RuleSet.pm6
@@ -1,4 +1,5 @@
 use JSON::Path;
+use JsonHound::PathMixin;
 use JsonHound::Violation;
 
 #| A set of validation rules to apply to the document, along with logic
@@ -85,7 +86,9 @@ class JsonHound::RuleSet {
     #| Takes a parsed JSON document and matches a given identifier type in it.
     method !match-identifier-in($type, $document --> List) {
         with self!find-json-path($type) -> $json-path {
-            eager %!json-path-cache{$json-path}.values($document).grep($type)
+            eager %!json-path-cache{$json-path}.paths-and-values($document)
+                    .map(-> $path, $value { $value but JsonHound::PathMixin($path) })
+                    .grep($type)
         }
         else {
             !!! "NYI non-json-path case of subset"

--- a/t/path.t
+++ b/t/path.t
@@ -1,0 +1,34 @@
+use Test;
+use JsonHound;
+use JsonHound::Violation;
+
+# A document to test against.
+my $sample-document = {
+    products => [
+            { name => 'Foo', available => True, stock => 5 },
+            { name => 'bar', available => False, stock => 0 },
+            { name => 'Baz', available => True, stock => 0 },
+            { name => 'Wat', available => True, stock => 0 }
+    ]
+}
+
+# A couple of simple matching rules.
+my subset Product is json-path('$.products[*]');
+
+# Add the rules (they are added contextually to the dynamic variable).
+my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+validate 'Path with index 1 not present', -> Product $product {
+    so $product.path ~~ /^ '$.products[' <[023]> ']' $/
+}
+
+# Check the violations are as expected.
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+is @violations.elems, 1, 'Got the expected number of violations';
+given @violations[0] {
+    isa-ok $_, JSONHound::Violation, 'Violation based on checking path worked';
+    is .name, 'Path with index 1 not present', 'Correct violation name';
+    is .arguments<Product><name>, 'bar', 'Correct argument';
+    is .arguments<Product>.path, '$.products[1]', 'Correct path';
+}
+
+done-testing;

--- a/t/simple-rules.t
+++ b/t/simple-rules.t
@@ -35,7 +35,8 @@ is @violations.grep(*.name eq 'Titlecased names').elems, 1,
 is @violations.grep(*.name eq 'Available is in stock').elems, 2,
         'Two violations of available is in stock rule';
 given @violations.first(*.name eq 'Titlecased names') {
-    is-deeply .arguments, { Product => { name => 'bar', available => False, stock => 0 } },
+    is-deeply .arguments.map({ .key => Hash.new(.value.pairs) }).hash,
+            { Product => { name => 'bar', available => False, stock => 0 } },
             'Arguments to failing rule correctly provided';
 }
 


### PR DESCRIPTION
This mixes in a `path` property to found fragments of the JSON, indicating the path in the document where it was matched. This is largely based on a new `paths-and-values` method in `JSON::Path`, which provides the two together (previously, that functionality was not available; it was either paths or values).

I also added the paths to the `jsonhound` tool output:

![image](https://user-images.githubusercontent.com/50259/47572044-514afe80-d93a-11e8-8db2-07b29a43f46d.png)

Providing an indication of where each one came from.