### PR TITLE
Enable reporting of values in rule names

### DIFF
--- a/examples/GigabitEthernetChecks.pm6
+++ b/examples/GigabitEthernetChecks.pm6
@@ -45,8 +45,9 @@ validate 'Missing auth port-control', -> Authentication $auth {
     $auth<port-control>:exists && $auth<port-control> eq 'auto'
 }
 
-validate 'Wrong reauthentication value', -> Authentication $auth {
-    $auth<timer><reauthenticate><value> == 1800
+validate {"Wrong reauthentication value (was $:value)"}, -> Authentication $auth {
+    my $value = $auth<timer><reauthenticate><value>;
+    $value == 1800 or report :$value
 }
 
 validate 'dot1x-not-set', -> VLan31 $ge {

--- a/lib/JsonHound.pm6
+++ b/lib/JsonHound.pm6
@@ -12,10 +12,11 @@ multi trait_mod:<is>(Mu:U $type, :$json-path! --> Nil) is export {
     $type.HOW does JSONPath[:$json-path];
 }
 
-#| Registers a validation, along with a name to use in reporting a failure.
-#| The C<&validator> argument should take one or more parameters that are
-#| subset types that will perform validation on the document.
-sub validate(Str $name, &validator --> Nil) is export {
+#| Registers a validation, along with a name to use in reporting a failure
+#| or a block that will produce a name. The C<&validator> argument should
+#| take one or more parameters that are subset types that will perform
+#| validation on the document.
+sub validate($name where Str | Block, &validator --> Nil) is export {
     if $*JSON-HOUND-RULESET ~~ JsonHound::RuleSet {
         $*JSON-HOUND-RULESET.add-validation($name, &validator);
     }
@@ -23,4 +24,9 @@ sub validate(Str $name, &validator --> Nil) is export {
         die "No JsonHound ruleset to register validation with\n" ~
                 "(this module must be used with the jsonHound tool)"
     }
+}
+
+#| Reports data to be included in the validation rule description.
+sub report(*%values --> Nil) is export {
+    %*JSON-HOUND-REPORTED ,= %values;
 }

--- a/lib/JsonHound.pm6
+++ b/lib/JsonHound.pm6
@@ -26,7 +26,9 @@ sub validate($name where Str | Block, &validator --> Nil) is export {
     }
 }
 
-#| Reports data to be included in the validation rule description.
-sub report(*%values --> Nil) is export {
+#| Reports data to be included in the validation rule description. Returns
+#| False to ease writing validation rules.
+sub report(*%values) is export {
     %*JSON-HOUND-REPORTED ,= %values;
+    return False;
 }

--- a/t/include-data-in-rule-names.t
+++ b/t/include-data-in-rule-names.t
@@ -1,0 +1,62 @@
+use Test;
+use JsonHound;
+use JsonHound::Violation;
+
+# Sample data to validate.
+my $sample-document = {
+    days => [
+        { distance => 10, team => ['Dave', 'Dana'] },
+        { distance => 12, team => ['Dave', 'Darya'] },
+        { distance => 9, team => ['Darya'] },
+        { distance => 40, team => ['Dana', 'Darya'] },
+    ]
+}
+
+# Matcher and rules with data included in the names.
+my subset Day is json-path('$.days[*]');
+my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+validate {"Maximum daily distance is 20, but got $:distance"}, -> Day $day {
+    if $day<distance> > 20 {
+        report distance => $day<distance>;
+        False
+    }
+    else {
+        True
+    }
+}
+validate {"Must have a team of 2 or more (have $:who)"}, -> Day $day {
+    if $day<team>.elems < 2 {
+        report who => $day<team>[0] // 'nobody';
+        False
+    }
+    else {
+        True
+    }
+}
+validate {"May forget $:something and not crash!"}, -> Day $day {
+    report bogus => 'value';
+    $day<distance> >= 10
+}
+
+# Check the violations are produced as expected, and problems warned about.
+my $warning;
+CONTROL {
+    when CX::Warn {
+        $warning ~= .Str;
+        .resume;
+    }
+}
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+is @violations.elems, 3, 'Got the expected number of violations';
+nok @violations.grep(* !~~ JSONHound::Violation),
+        'All violations are instances of JsonHound::Violation';
+is @violations.grep(*.name eq 'Maximum daily distance is 20, but got 40').elems, 1,
+        'Produced name correctly (1)';
+is @violations.grep(*.name eq 'Must have a team of 2 or more (have Darya)').elems, 1,
+        'Produced name correctly (2)';
+is @violations.grep(*.name eq 'May forget <MISSING> and not crash!').elems, 1,
+        'If reported data is missing, we still report the rule failure';
+like $warning, /something/, 'Got warning about missing reported data';
+like $warning, /bogus/, 'Got warning about unexpected reported data';
+
+done-testing;

--- a/t/include-data-in-rule-names.t
+++ b/t/include-data-in-rule-names.t
@@ -16,22 +16,10 @@ my $sample-document = {
 my subset Day is json-path('$.days[*]');
 my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
 validate {"Maximum daily distance is 20, but got $:distance"}, -> Day $day {
-    if $day<distance> > 20 {
-        report distance => $day<distance>;
-        False
-    }
-    else {
-        True
-    }
+    $day<distance> <= 20 or report distance => $day<distance>
 }
 validate {"Must have a team of 2 or more (have $:who)"}, -> Day $day {
-    if $day<team>.elems < 2 {
-        report who => $day<team>[0] // 'nobody';
-        False
-    }
-    else {
-        True
-    }
+    $day<team>.elems >= 2 or report who => $day<team>[0] // 'nobody'
 }
 validate {"May forget $:something and not crash!"}, -> Day $day {
     report bogus => 'value';


### PR DESCRIPTION
When validation fails, it's now possible for the rule name to include some information that was obtained as part of the validation process. The example rule file and also documentation are updated to cover this.