### PR TITLE
Add a debug information mechanism

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,15 +8,18 @@
         "JSON::Path"
     ],
     "provides": {
-        "JsonHound::Reporter::Compound": "lib/JsonHound/Reporter/Compound.pm6",
-        "JsonHound::Reporter::Syslog": "lib/JsonHound/Reporter/Syslog.pm6",
-        "JsonHound::Reporter::CLI": "lib/JsonHound/Reporter/CLI.pm6",
-        "JsonHound::Reporter::Nagios": "lib/JsonHound/Reporter/Nagios.pm6",
+        "JsonHound::DebugMode": "lib/JsonHound/DebugMode.pm6",
+        "JsonHound::DebugMessage": "lib/JsonHound/DebugMessage.pm6",
+        "JsonHound::RuleFeedback": "lib/JsonHound/RuleFeedback.pm6",
         "JsonHound::Violation": "lib/JsonHound/Violation.pm6",
         "JsonHound::Reporter": "lib/JsonHound/Reporter.pm6",
         "JsonHound::RuleSet": "lib/JsonHound/RuleSet.pm6",
         "JsonHound::PathMixin": "lib/JsonHound/PathMixin.pm6",
         "JsonHound::ValidationResult": "lib/JsonHound/ValidationResult.pm6",
+        "JsonHound::Reporter::Compound": "lib/JsonHound/Reporter/Compound.pm6",
+        "JsonHound::Reporter::Syslog": "lib/JsonHound/Reporter/Syslog.pm6",
+        "JsonHound::Reporter::CLI": "lib/JsonHound/Reporter/CLI.pm6",
+        "JsonHound::Reporter::Nagios": "lib/JsonHound/Reporter/Nagios.pm6",
         "JsonHound": "lib/JsonHound.pm6"
     },
     "name": "JSONHound",

--- a/META6.json
+++ b/META6.json
@@ -16,6 +16,7 @@
         "JsonHound::Reporter": "lib/JsonHound/Reporter.pm6",
         "JsonHound::RuleSet": "lib/JsonHound/RuleSet.pm6",
         "JsonHound::PathMixin": "lib/JsonHound/PathMixin.pm6",
+        "JsonHound::ValidationResult": "lib/JsonHound/ValidationResult.pm6",
         "JsonHound": "lib/JsonHound.pm6"
     },
     "name": "JSONHound",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ Is probably not what's wanted (however, in this case one would probably also get
 away with it, in so far as `0` and `1` are quite sensible exit codes for a Nagios
 plugin anyway).
 
+## Debug messages
+
+To produce a debug message in a validation rule, call `debug` and pass the
+message (whatever is passed will be coerced to a string, if it is not one
+already).
+
+```
+validate 'Missing global DHCP snooping', -> ArpInspection $inspection, GigabitEthernet $ge {
+    my $vlan = $ge<switchport><Cisco-IOS-XE-switch:access><vlan><vlan>;
+    debug "VLan is $vlan";
+    $vlan ~~ any(ranges($inspection))
+}
+```
+
+By default, these are not reported. However, they can be reported by the
+`cli` reporter by passing `--debug=failed` (only report debug output from
+failed validation rules) or `--debug=all` (report all debug output).
+
 ## Running with Docker
 
 You can also run the tool with docker directly from the git checkout

--- a/bin/jsonhound
+++ b/bin/jsonhound
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl6
 use JSON::Fast;
+use JsonHound::DebugMode;
 use JsonHound::Reporter::Compound;
 use JsonHound::Reporter::CLI;
 use JsonHound::Reporter::Nagios;
@@ -7,15 +8,17 @@ use JsonHound::Reporter::Syslog;
 use JsonHound::RuleSet;
 
 sub MAIN(
-        $validations,  #= Path to module specifying the validation to apply
-        *@json-files,  #= The JSON file(s) to validate
-        Str :$reporter #= Which reporter(s) to use, comma-separated (nagios,cli,syslog)
+        $validations,   #= Path to module specifying the validation to apply
+        *@json-files,   #= The JSON file(s) to validate
+        Str :$reporter, #= Which reporter(s) to use, comma-separated (nagios,cli,syslog)
+        Str :$debug     #= What debug messages to produce (none, failed, all)
         ) {
     my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
     my $rule-file = $validations.IO;
     CompUnit::RepositoryRegistry.use-repository:
             CompUnit::RepositoryRegistry.repository-for-spec($rule-file.parent.absolute);
     require "$rule-file.basename()";
+    my $debug-mode = debug-mode($debug);
 
     # We process the input files in parallel, but then do reporting of those
     # results one at a time. The `map` produces closures that are invoked with
@@ -25,12 +28,13 @@ sub MAIN(
     .($reporter-object) for @json-files.race(:1batch).map: -> $file {
         with slurp($file) -> $json {
             with try from-json($json) -> $parsed {
-                my $result = $*JSON-HOUND-RULESET.validate($parsed);
+                my $result = $*JSON-HOUND-RULESET.validate($parsed, :debug($debug-mode));
+                my @debug-messages = $result.debug-messages;
                 if $result.violations -> @violations {
-                    *.validation-error($file, @violations);
+                    *.validation-error($file, @violations, :@debug-messages);
                 }
                 else {
-                    *.ok($file);
+                    *.ok($file, :@debug-messages);
                 }
             }
             else {
@@ -43,6 +47,24 @@ sub MAIN(
     };
     $reporter-object.finalize;
     exit($reporter-object.exit-code // 0);
+}
+
+sub debug-mode($debug) {
+    given $debug || 'none' {
+        when 'none' {
+            JsonHound::DebugMode::None
+        }
+        when 'failed' {
+            JsonHound::DebugMode::Failed
+        }
+        when 'all' {
+            JsonHound::DebugMode::All
+        }
+        default {
+            note "Invalid debug mode '$_'";
+            exit 1;
+        }
+    }
 }
 
 sub build-reporter($reporter) {

--- a/bin/jsonhound
+++ b/bin/jsonhound
@@ -25,7 +25,8 @@ sub MAIN(
     .($reporter-object) for @json-files.race(:1batch).map: -> $file {
         with slurp($file) -> $json {
             with try from-json($json) -> $parsed {
-                if $*JSON-HOUND-RULESET.validate($parsed) -> @violations {
+                my $result = $*JSON-HOUND-RULESET.validate($parsed);
+                if $result.violations -> @violations {
                     *.validation-error($file, @violations);
                 }
                 else {

--- a/examples/GigabitEthernetChecks.pm6
+++ b/examples/GigabitEthernetChecks.pm6
@@ -35,7 +35,9 @@ validate 'Port detection failed', -> GigabitEthernet $ge {
 }
 
 validate 'Missing global DHCP snooping', -> ArpInspection $inspection, GigabitEthernet $ge {
-    $ge<switchport><Cisco-IOS-XE-switch:access><vlan><vlan> ~~ any(ranges($inspection))
+    my $vlan = $ge<switchport><Cisco-IOS-XE-switch:access><vlan><vlan>;
+    debug "VLan is $vlan";
+    $vlan ~~ any(ranges($inspection))
 }
 sub ranges($range-list) {
     $range-list.split(',').map({ /(\d+)['-'(\d+)]?/; $1 ?? (+$0 .. +$1) !! +$0 })
@@ -47,7 +49,9 @@ validate 'Missing auth port-control', -> Authentication $auth {
 
 validate {"Wrong reauthentication value (was $:value)"}, -> Authentication $auth {
     my $value = $auth<timer><reauthenticate><value>;
-    $value == 1800 or report :$value
+    debug "Reauthenticate value is $value";
+    report :$value;
+    $value == 1800
 }
 
 validate 'dot1x-not-set', -> VLan31 $ge {

--- a/lib/JsonHound.pm6
+++ b/lib/JsonHound.pm6
@@ -32,3 +32,10 @@ sub report(*%values) is export {
     %*JSON-HOUND-REPORTED ,= %values;
     return False;
 }
+
+#| Reports a debug message.
+sub debug(Str() $message --> Nil) is export {
+    with $*JSON-HOUND-DEBUG -> @messages {
+        push @messages, $message;
+    }
+}

--- a/lib/JsonHound/DebugMessage.pm6
+++ b/lib/JsonHound/DebugMessage.pm6
@@ -1,0 +1,7 @@
+use JsonHound::RuleFeedback;
+
+#| A debug message produced during validation.
+class JsonHound::DebugMessage does JsonHound::RuleFeedback {
+    #| The debug message.
+    has Str $.message is required;
+}

--- a/lib/JsonHound/DebugMode.pm6
+++ b/lib/JsonHound/DebugMode.pm6
@@ -1,0 +1,2 @@
+#| The validation rules that we collect any debug information for.
+enum JsonHound::DebugMode <None Failed All>;

--- a/lib/JsonHound/Reporter.pm6
+++ b/lib/JsonHound/Reporter.pm6
@@ -3,14 +3,14 @@
 #| also provide an exit code for the program.
 role JsonHound::Reporter {
     #| Called when a file is validated successfully.
-    method ok(Str $file --> Nil) { ... }
+    method ok(Str $file, :@debug-messages --> Nil) { ... }
 
     #| Called when there is a problem with the file that prevents validation
     #| even being attempted.
     method file-error(Str $file, Str $problem --> Nil) { ... }
 
     #| Called when a file has validation errors.
-    method validation-error(Str $file, @violations --> Nil) { ... }
+    method validation-error(Str $file, @violations, :@debug-messages --> Nil) { ... }
 
     #| Called when all files have been processed, to finalize the results.
     #| By default, does nothing.

--- a/lib/JsonHound/Reporter/CLI.pm6
+++ b/lib/JsonHound/Reporter/CLI.pm6
@@ -5,8 +5,20 @@ use Terminal::ANSIColor;
 class JsonHound::Reporter::CLI does JsonHound::Reporter {
     has $!failed = False;
 
-    method ok(Str $file --> Nil) {
-        note "$file: " ~ colored("passed validation", "green");
+    method ok(Str $file, :@debug-messages --> Nil) {
+        my $message = "$file: " ~ colored("passed validation", "green");
+        if @debug-messages {
+            $message ~= "\n";
+            for @debug-messages.categorize(*.name) -> (:key($name), :value(@messages)) {
+                my $first = @messages[0];
+                $message ~= "  " ~ colored("$name", "underline") ~
+                        " $first.file.IO.basename():$first.line()\n";
+                for @messages {
+                    $message ~= colored("    $_.message()\n", "yellow");
+                }
+            }
+        }
+        note $message;
     }
 
     method file-error(Str $file, Str $problem --> Nil) {
@@ -14,17 +26,33 @@ class JsonHound::Reporter::CLI does JsonHound::Reporter {
         $!failed = True;
     }
 
-    method validation-error(Str $file, @violations --> Nil) {
+    method validation-error(Str $file, @violations, :@debug-messages --> Nil) {
         my $message = "$file: " ~ colored("failed validation\n", "red");
+        my %debugs = @debug-messages.categorize(*.name);
         for @violations -> $v {
             $message ~= "  " ~ colored("$v.name()", "underline") ~
                     " $v.file.IO.basename():$v.line()\n";
+            with %debugs{$v.name} -> @messages {
+                for @messages {
+                    $message ~= colored("    $_.message()\n", "yellow");
+                }
+            }
+            %debugs{$v.name}:delete;
             for $v.arguments.sort(*.key).map(|*.kv) -> $name, $json {
                 $message ~= colored("    $name: ", "bold");
                 $message ~= colored("$json.path()\n", "blue");
                 $message ~= to-json($json).indent(6) ~ "\n";
             }
         }
+        for %debugs.kv -> $name, @messages {
+            my $first = @messages[0];
+            $message ~= "  " ~ colored("$name", "underline") ~
+                    " $first.file.IO.basename():$first.line()\n";
+            for @messages {
+                $message ~= colored("    $_.message()\n", "yellow");
+            }
+        }
+
         note $message;
     }
 

--- a/lib/JsonHound/Reporter/Compound.pm6
+++ b/lib/JsonHound/Reporter/Compound.pm6
@@ -5,16 +5,16 @@ use JsonHound::Reporter;
 class JsonHound::Reporter::Compound does JsonHound::Reporter {
     has JsonHound::Reporter @.reporters;
 
-    method ok(Str $file --> Nil) {
-        .ok($file) for @!reporters;
+    method ok(Str $file, :@debug-messages --> Nil) {
+        .ok($file, :@debug-messages) for @!reporters;
     }
 
     method file-error(Str $file, Str $problem --> Nil) {
         .file-error($file, $problem) for @!reporters;
     }
 
-    method validation-error(Str $file, @violations --> Nil) {
-        .validation-error($file, @violations) for @!reporters;
+    method validation-error(Str $file, @violations, :@debug-messages --> Nil) {
+        .validation-error($file, @violations, :@debug-messages) for @!reporters;
     }
 
     method finalize(--> Nil) {

--- a/lib/JsonHound/RuleFeedback.pm6
+++ b/lib/JsonHound/RuleFeedback.pm6
@@ -1,0 +1,12 @@
+#| Factors out the common information shared between various kinds
+#| of validation rule feedback (e.g. violations and debug messages).
+role JsonHound::RuleFeedback {
+    #| The name of the rule that failed.
+    has Str $.name is required;
+
+    #| The file where the validation rule was declared.
+    has Str $.file is required;
+
+    #| The line where the validation rule was declared.
+    has Int $.line is required;
+}

--- a/lib/JsonHound/RuleSet.pm6
+++ b/lib/JsonHound/RuleSet.pm6
@@ -1,4 +1,5 @@
 use JSON::Path;
+use JsonHound::DebugMode;
 use JsonHound::PathMixin;
 use JsonHound::ValidationResult;
 use JsonHound::Violation;
@@ -29,18 +30,31 @@ class JsonHound::RuleSet {
 
         #| Runs the validation on the identified data items, pushing any violations
         #| on to the passed violations array.
-        method add-violations(%identified, @violations) {
+        method add-violations(%identified, @violations, @debug-messages,
+                JsonHound::DebugMode :$debug! --> Nil) {
             my @arg-tuples = @!identifiers.elems == 1
                     ?? %identified{@!identifiers[0]}.map({ ($_,) })
                     !! [X] %identified{@!identifiers}.map(*.list);
             for @arg-tuples -> @args {
                 my %*JSON-HOUND-REPORTED;
-                unless &!validator(|@args) {
+                my $*JSON-HOUND-DEBUG = $debug == None ?? Nil !! [];
+                my $success = &!validator(|@args);
+                my $need-debug = $debug == All || $debug == Failed && !$success;
+                if $need-debug || !$success {
                     my $name = self!generate-name(%*JSON-HOUND-REPORTED);
-                    my %arguments = @!identifiers.map(*.^name) Z=> @args;
-                    push @violations, JSONHound::Violation.new:
-                            :$name, :%arguments, :file(&!validator.file),
-                            :line(&!validator.line);
+                    my $line = &!validator.line;
+                    my $file = &!validator.file;
+                    unless $success {
+                        my %arguments = @!identifiers.map(*.^name) Z=> @args;
+                        push @violations, JSONHound::Violation.new:
+                                :$name, :%arguments, :file($file),
+                                :line($line);
+                    }
+                    if $need-debug {
+                        append @debug-messages, $*JSON-HOUND-DEBUG.map: -> $message {
+                            JsonHound::DebugMessage.new: :$name, :$line, :$file, :$message
+                        }
+                    }
                 }
             }
         }
@@ -92,13 +106,14 @@ class JsonHound::RuleSet {
     }
 
     #| Runs the validations, and returns a validation result.
-    method validate($document --> JsonHound::ValidationResult) {
+    method validate($document, JsonHound::DebugMode :$debug = None --> JsonHound::ValidationResult) {
         my %identified := self!match-all-identifiers-in($document);
         my @violations;
+        my @debug-messages;
         for @!validations -> $rule {
-            $rule.add-violations(%identified, @violations)
+            $rule.add-violations(%identified, @violations, @debug-messages, :$debug)
         }
-        return JsonHound::ValidationResult.new(:@violations);
+        return JsonHound::ValidationResult.new(:@violations, :@debug-messages);
     }
 
     #| Takes a parsed JSON document and identifies all of the places that the given

--- a/lib/JsonHound/RuleSet.pm6
+++ b/lib/JsonHound/RuleSet.pm6
@@ -1,5 +1,6 @@
 use JSON::Path;
 use JsonHound::PathMixin;
+use JsonHound::ValidationResult;
 use JsonHound::Violation;
 
 #| A set of validation rules to apply to the document, along with logic
@@ -90,14 +91,14 @@ class JsonHound::RuleSet {
         @!validations.push($validation);
     }
 
-    #| Runs the validations, and returns a list of violations.
-    method validate($document --> Array) {
+    #| Runs the validations, and returns a validation result.
+    method validate($document --> JsonHound::ValidationResult) {
         my %identified := self!match-all-identifiers-in($document);
         my @violations;
         for @!validations -> $rule {
             $rule.add-violations(%identified, @violations)
         }
-        @violations
+        return JsonHound::ValidationResult.new(:@violations);
     }
 
     #| Takes a parsed JSON document and identifies all of the places that the given

--- a/lib/JsonHound/ValidationResult.pm6
+++ b/lib/JsonHound/ValidationResult.pm6
@@ -1,5 +1,11 @@
+use JsonHound::DebugMessage;
+use JsonHound::Violation;
+
 #| The results of a validation.
 class JsonHound::ValidationResult {
     #| Any rule violations that were found.
-    has @.violations;
+    has JSONHound::Violation @.violations;
+
+    #| Any debug messages that were produced.
+    has JsonHound::DebugMessage @.debug-messages;
 }

--- a/lib/JsonHound/ValidationResult.pm6
+++ b/lib/JsonHound/ValidationResult.pm6
@@ -1,0 +1,5 @@
+#| The results of a validation.
+class JsonHound::ValidationResult {
+    #| Any rule violations that were found.
+    has @.violations;
+}

--- a/lib/JsonHound/Violation.pm6
+++ b/lib/JsonHound/Violation.pm6
@@ -1,14 +1,7 @@
+use JsonHound::RuleFeedback;
+
 #| Details of a validation rules violation.
-class JSONHound::Violation {
-    #| The name of the rule that failed.
-    has Str $.name is required;
-
-    #| The file where the validation rule was declared.
-    has Str $.file is required;
-
-    #| The line where the validation rule was declared.
-    has Int $.line is required;
-
+class JSONHound::Violation does JsonHound::RuleFeedback {
     #| Mapping of the name of the identified subest taken as a parameter in
     #| the failing rule to the JSON that was unacceptable.
     has %.arguments;

--- a/t/debug-messages.t
+++ b/t/debug-messages.t
@@ -1,0 +1,51 @@
+use Test;
+use JsonHound;
+use JsonHound::DebugMessage;
+use JsonHound::DebugMode;
+
+# Sample data to validate.
+my $sample-document = {
+    days => [
+        { distance => 10, team => ['Dave', 'Dana'] },
+        { distance => 12, team => ['Dave', 'Darya'] },
+        { distance => 9, team => ['Darya'] },
+        { distance => 40, team => ['Dana', 'Darya'] },
+    ]
+}
+
+my subset Day is json-path('$.days[*]');
+my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+validate "Maximum daily distance is 20", -> Day $day {
+    debug "Distance is $day<distance>";
+    $day<distance> <= 20
+}
+validate "Must have a team of 2 or more", -> Day $day {
+    debug "Team has $day<team>.elems() member(s)";
+    $day<team>.elems >= 2
+}
+
+given $*JSON-HOUND-RULESET.validate($sample-document, :debug(None)) {
+    is .debug-messages.elems, 0, 'No debug messages when debug mode is None';
+}
+
+given $*JSON-HOUND-RULESET.validate($sample-document, :debug(Failed)) {
+    is .debug-messages.elems, 2,
+            'In Failed mode, debug messages from failing rules';
+    given .debug-messages.sort(*.name) {
+        is .[0].name, "Maximum daily distance is 20",
+                'First debug message from correct rule';
+        is .[0].message, "Distance is 40",
+                'First debug messages has correct text';
+        is .[1].name, "Must have a team of 2 or more",
+                'Second debug message from correct rule';
+        is .[1].message, "Team has 1 member(s)",
+                'Second debug messages has correct text';
+    }
+}
+
+given $*JSON-HOUND-RULESET.validate($sample-document, :debug(All)) {
+    is .debug-messages.elems, 8,
+            'In All mode, debug messages even from passing rules';
+}
+
+done-testing;

--- a/t/derived-where.t
+++ b/t/derived-where.t
@@ -22,7 +22,7 @@ validate 'Problem on known vlan', -> KnownVLan $port {
     not $port<problem>:exists
 }
 
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
 is @violations.elems, 1, 'Only one violation found';
 given @violations[0] {
     isa-ok $_, JSONHound::Violation, 'Got a violation object';

--- a/t/include-data-in-rule-names.t
+++ b/t/include-data-in-rule-names.t
@@ -34,7 +34,7 @@ CONTROL {
         .resume;
     }
 }
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
 is @violations.elems, 3, 'Got the expected number of violations';
 nok @violations.grep(* !~~ JSONHound::Violation),
         'All violations are instances of JsonHound::Violation';

--- a/t/multi-identifier-rules.t
+++ b/t/multi-identifier-rules.t
@@ -29,7 +29,7 @@ sub ranges($range-list) {
 }
 
 # Check the violations are as expected.
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
 is @violations.elems, 2, 'Correct number of violations detected';
 nok @violations.grep(* !~~ JSONHound::Violation),
         'All violations are instances of JsonHound::Violation';

--- a/t/path.t
+++ b/t/path.t
@@ -22,7 +22,7 @@ validate 'Path with index 1 not present', -> Product $product {
 }
 
 # Check the violations are as expected.
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
 is @violations.elems, 1, 'Got the expected number of violations';
 given @violations[0] {
     isa-ok $_, JSONHound::Violation, 'Violation based on checking path worked';

--- a/t/simple-rules.t
+++ b/t/simple-rules.t
@@ -1,5 +1,6 @@
 use Test;
 use JsonHound;
+use JsonHound::ValidationResult;
 use JsonHound::Violation;
 
 # A document to test against.
@@ -26,7 +27,8 @@ validate 'Available is in stock', -> AvailableProduct $product {
 }
 
 # Check the violations are as expected.
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document);
+my $result = $*JSON-HOUND-RULESET.validate($sample-document);
+my @violations = $result.violations;
 is @violations.elems, 3, 'Got the expected number of violations';
 nok @violations.grep(* !~~ JSONHound::Violation),
         'All violations are instances of JsonHound::Violation';


### PR DESCRIPTION
This adds a mechanism for validation rules to provide debug information. The information is collected only if a `--debug=failed` or `--debug=all` option is passed at the command line (when `--debug=failed` is passed, it is only preserved for rules that fail validation).

The debug information is passed along to all reporters. The CLI reporter has been updated in order to output debug messages. When the debug messages are for a failed validation rule, they are reported together with the validation rule.

Example output in `failed` mode (in yellow):

![image](https://user-images.githubusercontent.com/50259/49330010-afe24880-f588-11e8-9431-2375ee099080.png)
