### PR TITLE
Provide `Either[...]` for disjunctions of identifiers

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -20,6 +20,7 @@
         "JsonHound::Reporter::Syslog": "lib/JsonHound/Reporter/Syslog.pm6",
         "JsonHound::Reporter::CLI": "lib/JsonHound/Reporter/CLI.pm6",
         "JsonHound::Reporter::Nagios": "lib/JsonHound/Reporter/Nagios.pm6",
+        "Either": "lib/Either.pm6",
         "JsonHound": "lib/JsonHound.pm6"
     },
     "name": "JSONHound",

--- a/README.md
+++ b/README.md
@@ -128,6 +128,40 @@ It is allowed to have multiple such parameters, which may be provided with a sin
 call to `report` or multiple calls to `report` over time. Do as is most comfortable
 for the rule being implemented.
 
+## Disjunctions of identifiers
+
+It's possible to use the `Either[...]` construct to produce a disjunction of two
+or more identifiers. For example, given:
+
+```
+subset MegabitEthernet
+        is json-path(q[$['Cisco-IOS-XE-native:native'].interface.MegabitEthernet[*]]);
+subset GigabitEthernet
+        is json-path(q[$['Cisco-IOS-XE-native:native'].interface.GigabitEthernet[*]]);
+```
+
+One could write a validation rule that applies to either by doing:
+
+```
+validate 'Ethernet correctly configured', -> Either[MegabitEthernet, GigabitEthernet] $eth {
+    ...
+}
+```
+
+If the same `Either` expression would be repeated multiple times, it may be factored
+out by declaring a `constant`:
+
+```
+my constant Ethernet = Either[MegabitEthernet, GigabitEthernet];
+
+validate 'Ethernet correctly configured', -> Ethernet $eth {
+    ...
+}
+```
+
+A validation rule using multiple `Either` types will be invoked for all
+permutations of matches, as is usually the case with multi-parameter rules.
+
 ## The command line interface
 
 Once installed, run with:

--- a/lib/Either.pm6
+++ b/lib/Either.pm6
@@ -1,0 +1,18 @@
+#| Provides a mechanism for specifying a disjunction of types,
+#| allowing for the types to be fully retrieved.
+class Either {
+    has @.either-types;
+
+    method ACCEPTS($topic) {
+        $topic ~~ any(@!either-types)
+    }
+
+    method ^parameterize($, *@either-types) {
+        Either.new(:@either-types)
+    }
+
+    method ^accepts_type(|c) {
+        c[1].DEFINITE
+    }
+}
+BEGIN Metamodel::Primitives.configure_type_checking(Either, (Either, Any, Mu), :call_accepts);

--- a/t/either.t
+++ b/t/either.t
@@ -5,8 +5,8 @@ use Test;
 # Sample data to validate.
 my $sample-document = {
     days => [
-        { distance => 10, team => ['Dave', 'Dana'] },
-        { distance => 12, team => ['Dave', 'Darya'] },
+        { distance => 10, team => ['Dave', 'Doris'] },
+        { distance => 12, team => ['Dave', 'Darya', 'Daniel', 'Doris'] },
         { distance => 9, team => ['Darya'] },
         { distance => 40, team => ['Dana', 'Darya'] },
     ]
@@ -14,17 +14,38 @@ my $sample-document = {
 
 my subset Short is json-path('$.days[*]') where { .<distance> < 10 };
 my subset Long is json-path('$.days[*]') where { .<distance> > 25 };
+my subset Small is json-path('$.days[*].team') where .elems <= 1;
+my subset Large is json-path('$.days[*].team') where .elems >= 4;
 
-my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
-validate "Out of range", -> Either[Short, Long] $day {
-    False
+{
+    my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+    validate "Out of range", -> Either[Short, Long] $day {
+        False
+    }
+
+    my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
+    is @violations.elems, 2, 'Got expected number of violations';
+    is @violations.grep(?*.arguments<Short>).elems, 1,
+            'Once matched Short';
+    is @violations.grep(?*.arguments<Long>).elems, 1,
+            'Once matched Long';
 }
 
-my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
-is @violations.elems, 2, 'Got expected number of violations';
-is @violations.grep(?*.arguments<Short>).elems, 1,
-        'Once matched Short';
-is @violations.grep(?*.arguments<Long>).elems, 1,
-        'Once matched Long';
+{
+    my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+    validate "Out of range", -> Either[Short, Long] $day, Either[Small, Large] $team {
+        False
+    }
+    my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
+    is @violations.elems, 2 * 2, 'Multiple Either[...] types produce combinations';
+    is @violations.grep({ so .arguments<Short> && .arguments<Small> }).elems, 1,
+            'Found Short/Small combination';
+    is @violations.grep({ so .arguments<Short> && .arguments<Large> }).elems, 1,
+            'Found Short/Large combination';
+    is @violations.grep({ so .arguments<Long> && .arguments<Small> }).elems, 1,
+            'Found Long/Small combination';
+    is @violations.grep({ so .arguments<Long> && .arguments<Large> }).elems, 1,
+            'Found Long/Large combination';
+}
 
 done-testing;

--- a/t/either.t
+++ b/t/either.t
@@ -1,0 +1,30 @@
+use Either;
+use JsonHound;
+use Test;
+
+# Sample data to validate.
+my $sample-document = {
+    days => [
+        { distance => 10, team => ['Dave', 'Dana'] },
+        { distance => 12, team => ['Dave', 'Darya'] },
+        { distance => 9, team => ['Darya'] },
+        { distance => 40, team => ['Dana', 'Darya'] },
+    ]
+}
+
+my subset Short is json-path('$.days[*]') where { .<distance> < 10 };
+my subset Long is json-path('$.days[*]') where { .<distance> > 25 };
+
+my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+validate "Out of range", -> Either[Short, Long] $day {
+    False
+}
+
+my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
+is @violations.elems, 2, 'Got expected number of violations';
+is @violations.grep(?*.arguments<Short>).elems, 1,
+        'Once matched Short';
+is @violations.grep(?*.arguments<Long>).elems, 1,
+        'Once matched Long';
+
+done-testing;

--- a/t/either.t
+++ b/t/either.t
@@ -48,4 +48,19 @@ my subset Large is json-path('$.days[*].team') where .elems >= 4;
             'Found Long/Large combination';
 }
 
+{
+    my constant ShortOrLong = Either[Short, Long];
+    my $*JSON-HOUND-RULESET = JsonHound::RuleSet.new;
+    validate "Out of range", -> ShortOrLong $day {
+        False
+    }
+
+    my @violations = $*JSON-HOUND-RULESET.validate($sample-document).violations;
+    is @violations.elems, 2, 'Got expected number of violations when using constant';
+    is @violations.grep(?*.arguments<Short>).elems, 1,
+            'Once matched Short when using constant';
+    is @violations.grep(?*.arguments<Long>).elems, 1,
+            'Once matched Long when using constant';
+}
+
 done-testing;


### PR DESCRIPTION
This makes it possible to do things like:

```
subset MegabitEthernet
        is json-path(q[$['Cisco-IOS-XE-native:native'].interface.MegabitEthernet[*]]);
subset GigabitEthernet
        is json-path(q[$['Cisco-IOS-XE-native:native'].interface.GigabitEthernet[*]]);

validate 'Ethernet correctly configured', -> Either[MegabitEthernet, GigabitEthernet] $eth {
    ...
}
```

To have the validation rule apply to either case.