### PR TITLE
missing source-url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "license": "MIT",
+    "source-url": "git://github.com/oposs/jsonhound.git",
     "auth": "Oetiker+Partner",
     "depends": [
         "JSON::Fast",


### PR DESCRIPTION
Travis fails: https://github.com/perl6/ecosystem/pull/464

not ok 1 - Downloading https://raw.githubusercontent.com/oposs/jsonhound/master/META6.json
Failed test 'Downloading https://raw.githubusercontent.com/oposs/jsonhound/master/META6.json'
at ./.travis/testpackagemeta.p6 line 44
no source-url defined in META file